### PR TITLE
Better fontify -- a macro, and character keywords

### DIFF
--- a/settings/d2-dev-lisp.el
+++ b/settings/d2-dev-lisp.el
@@ -206,6 +206,9 @@
     "notinline" "optimize" "otherwise" "safety" "satisfies" "space" "special"
     "speed" "structure" "type"))
 
+(defvar *common-lisp-character-names*
+  '("newline" "space" "rubout" "page" "tab" "backspace" "return" "linefeed"))
+
 (defmacro add-regexes (mode &rest symbol-face)
   `(progn
      ,@(cl-loop for s in symbol-face
@@ -219,4 +222,5 @@
  (*common-lisp-built-in-functions* . font-lock-function-name-face)
  (*common-lisp-built-in-variables* . font-lock-variable-name-face)
  (*common-lisp-built-in-types* . font-lock-type-face)
- (*common-lisp-built-in-symbols* . font-lock-builtin-face))
+ (*common-lisp-built-in-symbols* . font-lock-builtin-face)
+ (*common-lisp-character-names* . font-lock-variable-name-face))

--- a/settings/d2-dev-lisp.el
+++ b/settings/d2-dev-lisp.el
@@ -1,3 +1,4 @@
+(require 'cl-lib)
 (defvar *common-lisp-built-in-functions*
   '("+" "-" "/" "/=" "<" "<=" "=" ">" ">=" "*" "1-" "1+" "abs" "acons" "acos"
     "acosh" "add-method" "adjoin" "adjustable-array-p" "adjust-array"
@@ -205,18 +206,17 @@
     "notinline" "optimize" "otherwise" "safety" "satisfies" "space" "special"
     "speed" "structure" "type"))
 
-(font-lock-add-keywords
- 'lisp-mode
- `((,(regexp-opt *common-lisp-built-in-functions* 'symbols) . font-lock-function-name-face)))
-
-(font-lock-add-keywords
- 'lisp-mode
- `((,(regexp-opt *common-lisp-built-in-variables* 'symbols) . font-lock-variable-name-face)))
-
-(font-lock-add-keywords
- 'lisp-mode
- `((,(regexp-opt *common-lisp-built-in-types* 'symbols) . font-lock-type-face)))
-
-(font-lock-add-keywords
- 'lisp-mode
- `((,(regexp-opt *common-lisp-built-in-symbols* 'symbols) . font-lock-builtin-face)))
+(defmacro add-regexes (mode &rest symbol-face)
+  `(progn
+     ,@(cl-loop for s in symbol-face
+                collect
+                `(font-lock-add-keywords
+                  ',mode
+                  `((,(regexp-opt ,(car s) 'symbols)
+                     . ,(cdr ',s)))))))
+(add-regexes
+ lisp-mode
+ (*common-lisp-built-in-functions* . font-lock-function-name-face)
+ (*common-lisp-built-in-variables* . font-lock-variable-name-face)
+ (*common-lisp-built-in-types* . font-lock-type-face)
+ (*common-lisp-built-in-symbols* . font-lock-builtin-face))


### PR DESCRIPTION
The macro `add-key` reduces code duplication and is easier to read/add new keys.

The new variable `*common-lisp-character-names*` includes [special whitespace character names from the hypespec](http://www.lispworks.com/documentation/HyperSpec/Body/13_ag.htm). I used the variable name face, since that seemed like the closest thing, and `space` is also shadowed there.

If you don't like the new symbols `*common-lisp-character-names*` you can cherry-pick just the first commit.